### PR TITLE
Implement Object Code Loader

### DIFF
--- a/src/loader.py
+++ b/src/loader.py
@@ -1,0 +1,110 @@
+class Loader:
+    """
+    Implements an Object Code Loader for the SIC Emulator.
+    Supports Header (H), Text (T), End (E), and Modification (M) records.
+    """
+
+    def __init__(self, machine):
+        """
+        Initializes the loader with a reference to the SIC machine.
+
+        Args:
+            machine: An instance of SICMachine.
+        """
+        self.machine = machine
+
+    def load(self, object_code: str, load_address: int = None):
+        """
+        Parses and loads SIC object code into the machine's memory.
+
+        Args:
+            object_code: A string containing the object code lines.
+            load_address: Optional address to load the program at. If provided,
+                         relocation will be performed using this as the base address.
+        """
+        lines = object_code.strip().split('\n')
+        program_base_address = 0
+        actual_base_address = 0
+        relocation_offset = 0
+
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+
+            record_type = line[0]
+
+            if record_type == 'H':
+                # H^progname^startaddr^length
+                # H: 1, Name: 2-7, Start: 8-13, Length: 14-19
+                # program_name = line[1:7].strip()
+                program_base_address = int(line[7:13], 16)
+                # program_length = int(line[13:19], 16)
+
+                if load_address is not None:
+                    actual_base_address = load_address
+                    relocation_offset = actual_base_address - program_base_address
+                else:
+                    actual_base_address = program_base_address
+                    relocation_offset = 0
+
+            elif record_type == 'T':
+                # T^startaddr^length^objcode
+                # T: 1, Start: 2-7, Length: 8-9, Code: 10-69
+                start_addr = int(line[1:7], 16)
+                length = int(line[7:9], 16)
+                obj_code_hex = line[9:]
+
+                target_address = start_addr + relocation_offset
+
+                for i in range(0, length * 2, 2):
+                    byte_val = int(obj_code_hex[i:i+2], 16)
+                    self.machine.memory.write_byte(target_address + (i // 2), byte_val)
+
+            elif record_type == 'M':
+                # M^startaddr^length^flag^symbol
+                # M: 1, Start: 2-7, Length: 8-9, Flag: 10, Symbol: 11-16
+                if load_address is not None:
+                    start_addr = int(line[1:7], 16)
+                    length_half_bytes = int(line[7:9], 16)
+                    modification_flag = line[9]
+
+                    target_address = start_addr + relocation_offset
+
+                    if length_half_bytes == 6:
+                        current_val = self.machine.memory.read_word(target_address)
+                        if modification_flag == '+':
+                            new_val = (current_val + relocation_offset) & 0xFFFFFF
+                        elif modification_flag == '-':
+                            new_val = (current_val - relocation_offset) & 0xFFFFFF
+                        else:
+                            new_val = current_val
+                        self.machine.memory.write_word(target_address, new_val)
+                    elif length_half_bytes == 5:
+                        # Handle 20-bit address modification
+                        b1 = self.machine.memory.read_byte(target_address)
+                        b2 = self.machine.memory.read_byte(target_address + 1)
+                        b3 = self.machine.memory.read_byte(target_address + 2)
+
+                        val = (b1 << 16) | (b2 << 8) | b3
+                        addr_part = val & 0xFFFFF
+
+                        if modification_flag == '+':
+                            addr_part = (addr_part + relocation_offset) & 0xFFFFF
+                        elif modification_flag == '-':
+                            addr_part = (addr_part - relocation_offset) & 0xFFFFF
+
+                        val = (val & 0xF00000) | addr_part
+
+                        self.machine.memory.write_byte(target_address, (val >> 16) & 0xFF)
+                        self.machine.memory.write_byte(target_address + 1, (val >> 8) & 0xFF)
+                        self.machine.memory.write_byte(target_address + 2, val & 0xFF)
+
+            elif record_type == 'E':
+                # E^startaddr
+                # E: 1, Start: 2-7
+                if len(line) >= 7:
+                    exec_start_addr = int(line[1:7], 16)
+                    self.machine.registers.PC = exec_start_addr + relocation_offset
+                else:
+                    self.machine.registers.PC = actual_base_address

--- a/src/machine.py
+++ b/src/machine.py
@@ -1,6 +1,7 @@
 from .memory import Memory
 from .registers import Registers
 from .cpu import CPU
+from .loader import Loader
 
 class SICMachine:
     """
@@ -41,6 +42,17 @@ class SICMachine:
         for word in program:
             self.memory.write_word(current_address, word)
             current_address += 3
+
+    def load_object_code(self, object_code: str, load_address: int = None):
+        """
+        Parses and loads SIC object code into memory.
+
+        Args:
+            object_code: A string containing the object code lines.
+            load_address: Optional address to load the program at.
+        """
+        loader = Loader(self)
+        loader.load(object_code, load_address)
 
     def run(self, steps: int = 100):
         """

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,117 @@
+import unittest
+from src.machine import SICMachine
+from src.loader import Loader
+
+class TestLoader(unittest.TestCase):
+    def setUp(self):
+        self.machine = SICMachine()
+        self.loader = Loader(self.machine)
+
+    def test_load_header_record(self):
+        # H^COPY  ^001000^00107A
+        # Note: In standard SIC, names are 6 chars, addresses 6 hex digits
+        obj_code = "HCOPY  00100000107A"
+        # For now, just ensuring it doesn't crash and maybe stores metadata if we want
+        self.loader.load(obj_code)
+        # Check if some internal state is updated or if it just moves on
+        # Probably nothing to check in memory yet
+
+    def test_load_text_record(self):
+        # H record is usually required first to set context
+        # T^001000^02^001003
+        # T, then 6 digits address, 2 digits length, then hex pairs
+        obj_code = "HCOPY  00100000107A\nT00100003001003"
+        self.loader.load(obj_code)
+
+        # Address 001000 should have 001003
+        val = self.machine.memory.read_word(0x1000)
+        self.assertEqual(val, 0x001003)
+
+    def test_load_end_record(self):
+        # E^001000
+        obj_code = "HCOPY  00100000107A\nT00100003001003\nE001000"
+        self.loader.load(obj_code)
+
+        # PC should be set to 0x1000
+        self.assertEqual(self.machine.registers.PC, 0x1000)
+
+    def test_multiple_text_records(self):
+        obj_code = (
+            "HCOPY  00100000107A\n"
+            "T00100003001003\n"
+            "T00100303001006\n"
+            "E001000"
+        )
+        self.loader.load(obj_code)
+        self.assertEqual(self.machine.memory.read_word(0x1000), 0x001003)
+        self.assertEqual(self.machine.memory.read_word(0x1003), 0x001006)
+        self.assertEqual(self.machine.registers.PC, 0x1000)
+
+    def test_relocation_record(self):
+        # M^001001^04+COPY
+        # This is more advanced. SIC/XE relocation.
+        # M, then 6 digits start addr, 2 digits length (half-bytes), flag, symbol
+        # For absolute loader, relocation might be added to a base load address.
+
+        # Let's say we load at 0x2000 instead of 0x1000
+        obj_code = (
+            "HCOPY  00000000107A\n" # Program starts at 0 relative
+            "T00000003000003\n"     # Word at 000000 is 000003 (address to be relocated)
+            "M00000006+COPY\n"      # Relocate 6 half-bytes (3 bytes) at addr 0
+            "E000000"
+        )
+        # Load at 0x2000
+        self.loader.load(obj_code, load_address=0x2000)
+
+        # The word at 0x2000 should be 0x000003 + 0x2000 = 0x002003
+        self.assertEqual(self.machine.memory.read_word(0x2000), 0x2003)
+        # PC should be 0x2000
+        self.assertEqual(self.machine.registers.PC, 0x2000)
+
+    def test_relocation_record_format4(self):
+        # Format 4 instruction: +JSUB RDREC (48 10 10 36 in hex, if RDREC is at 0x1036)
+        # If RDREC is relative to program start (0), and we load at 0x2000.
+        # Record: T0000010448100000  (assuming JSUB is at 0001, address field is 00000)
+        # Modification record: M00000205+COPY (modify 5 half-bytes starting at 0002)
+
+        obj_code = (
+            "HCOPY  00000000107A\n"
+            "T0000010448100000\n" # JSUB at addr 1, 4 bytes long. Byte 1 is 48, Byte 2 is 10, Byte 3 & 4 are 00 00.
+                                  # The 20-bit address starts at Byte 2's last 4 bits.
+                                  # Wait, 48 is Byte 0. 10 is Byte 1. 00 is Byte 2. 00 is Byte 3.
+                                  # Field to modify starts at address + 1 = 2.
+                                  # Wait, address + 1 is Byte 1.
+                                  # Byte 0: 48
+                                  # Byte 1: 10
+                                  # Byte 2: 00
+                                  # Byte 3: 00
+                                  # 20 bit address is in Byte 1 (last 4 bits), Byte 2, Byte 3.
+                                  # So M00000205 means it starts at Byte 1.
+            "M00000205+COPY\n"
+            "E000000"
+        )
+
+        # In our memory:
+        # Address 1: 48
+        # Address 2: 10
+        # Address 3: 00
+        # Address 4: 00
+
+        self.loader.load(obj_code, load_address=0x2000)
+
+        # After relocation at 0x2000:
+        # Addresses in memory are 0x2001, 0x2002, 0x2003, 0x2004.
+        # Original values: 0x48, 0x10, 0x00, 0x00
+        # Relocation at 0x2002 (target_address = 0x0002 + 0x2000 = 0x2002)
+        # Read 3 bytes from 0x2002: 10, 00, 00 -> 0x100000
+        # Add 0x2000 to last 20 bits (0x00000): 0x00000 + 0x2000 = 0x02000
+        # Combine back: 0x100000 | 0x02000 = 0x102000
+        # Write back to 0x2002: 10, 20, 00
+
+        self.assertEqual(self.machine.memory.read_byte(0x2001), 0x48)
+        self.assertEqual(self.machine.memory.read_byte(0x2002), 0x10)
+        self.assertEqual(self.machine.memory.read_byte(0x2003), 0x20)
+        self.assertEqual(self.machine.memory.read_byte(0x2004), 0x00)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented an Object Code Loader for the SIC Emulator. The loader supports standard SIC/XE object code format (H, T, M, E records) and handles relocation during the loading process. It has been integrated into the `SICMachine` class and verified with unit tests.

Fixes #3

---
*PR created automatically by Jules for task [11659221845753513358](https://jules.google.com/task/11659221845753513358) started by @jonaschen*