### PR TITLE
Add Support for Additional IO Devices (Disks, Tapes, Consoles)

### DIFF
--- a/src/cpu.py
+++ b/src/cpu.py
@@ -1,6 +1,7 @@
 from .registers import Registers
 from .memory import Memory
 from .instruction import Instruction
+from .devices import DeviceManager
 
 class CPU:
     """
@@ -8,16 +9,18 @@ class CPU:
     It orchestrates the fetch-decode-execute cycle.
     """
 
-    def __init__(self, registers: Registers, memory: Memory):
+    def __init__(self, registers: Registers, memory: Memory, device_manager: DeviceManager = None):
         """
-        Initializes the CPU with references to the registers and memory.
+        Initializes the CPU with references to the registers, memory, and device manager.
         
         Args:
             registers: The machine's register file.
             memory: The machine's main memory.
+            device_manager: The machine's IO device manager.
         """
         self.registers = registers
         self.memory = memory
+        self.device_manager = device_manager
         # Map opcodes to their handler methods.
         self.opcodes = {
             0x00: self._lda,
@@ -27,6 +30,9 @@ class CPU:
             0x28: self._comp,
             0x3C: self._j,
             0x30: self._jeq,
+            0xD8: self._rd,
+            0xDC: self._wd,
+            0xE0: self._td,
         } 
 
     def fetch(self) -> Instruction:
@@ -137,3 +143,43 @@ class CPU:
             self.registers.PC = effective_address
         # If the condition is not met, the PC retains its incremented value from step().
 
+    def _td(self, instr: Instruction):
+        """
+        Executes the TD (Test Device) instruction.
+        Opcode: 0xE0
+        Sets SW to '<' if ready, '=' if busy.
+        """
+        effective_address = self._get_effective_address(instr)
+        device_id = effective_address & 0xFF
+        device = self.device_manager.get_device(device_id) if self.device_manager else None
+
+        if device and device.test():
+            self.registers.SW = ord('<')
+        else:
+            self.registers.SW = ord('=')
+
+    def _rd(self, instr: Instruction):
+        """
+        Executes the RD (Read Device) instruction.
+        Opcode: 0xD8
+        Reads a byte into the rightmost 8 bits of A.
+        """
+        effective_address = self._get_effective_address(instr)
+        device_id = effective_address & 0xFF
+        device = self.device_manager.get_device(device_id) if self.device_manager else None
+
+        byte = device.read() if device else 0
+        self.registers.A = (self.registers.A & 0xFFFF00) | (byte & 0xFF)
+
+    def _wd(self, instr: Instruction):
+        """
+        Executes the WD (Write Device) instruction.
+        Opcode: 0xDC
+        Writes the rightmost 8 bits of A to the device.
+        """
+        effective_address = self._get_effective_address(instr)
+        device_id = effective_address & 0xFF
+        device = self.device_manager.get_device(device_id) if self.device_manager else None
+
+        if device:
+            device.write(self.registers.A & 0xFF)

--- a/src/devices.py
+++ b/src/devices.py
@@ -1,0 +1,126 @@
+import io
+
+class IODevice:
+    """
+    Abstract base class for all Input/Output devices in the SIC emulator.
+    """
+    def test(self) -> bool:
+        """Returns True if the device is ready, False if busy."""
+        return True
+
+    def reset(self):
+        """Resets the device to its initial state."""
+        pass
+
+    def read(self) -> int:
+        """Reads a single byte from the device."""
+        return 0
+
+    def write(self, value: int):
+        """Writes a single byte to the device."""
+        pass
+
+class ConsoleInputDevice(IODevice):
+    """
+    Simulates terminal input.
+    """
+    def __init__(self):
+        self._buffer = []
+
+    def set_input(self, data: str):
+        """Pre-loads the input buffer with a string."""
+        self._buffer.extend([ord(c) for c in data])
+
+    def test(self) -> bool:
+        """Ready if there is data in the buffer."""
+        return len(self._buffer) > 0
+
+    def reset(self):
+        """Clears the input buffer."""
+        self._buffer = []
+
+    def read(self) -> int:
+        """Reads the next byte from the buffer."""
+        if self._buffer:
+            return self._buffer.pop(0)
+        return 0
+
+class ConsoleOutputDevice(IODevice):
+    """
+    Simulates terminal output.
+    """
+    def __init__(self):
+        self._output = []
+
+    def write(self, value: int):
+        """Writes a byte (as a character) to the output buffer."""
+        self._output.append(chr(value & 0xFF))
+
+    def reset(self):
+        """Clears the output buffer."""
+        self._output = []
+
+    def get_output(self) -> str:
+        """Returns the accumulated output as a string."""
+        return "".join(self._output)
+
+class FileBackedDevice(IODevice):
+    """
+    Base class for devices that are backed by a byte stream.
+    Used for Disk and Tape simulations.
+    """
+    def __init__(self):
+        self._stream = io.BytesIO()
+
+    def reset(self):
+        """Resets the stream to an empty state."""
+        self._stream = io.BytesIO()
+
+    def read(self) -> int:
+        """Reads a single byte from the stream."""
+        byte = self._stream.read(1)
+        if not byte:
+            return 0
+        return byte[0]
+
+    def write(self, value: int):
+        """Writes a single byte to the stream."""
+        self._stream.write(bytes([value & 0xFF]))
+
+    def seek(self, offset: int):
+        """Seeks to a specific position in the stream."""
+        self._stream.seek(offset)
+
+class DiskDevice(FileBackedDevice):
+    """
+    Simulates a Disk device.
+    """
+    pass
+
+class TapeDevice(FileBackedDevice):
+    """
+    Simulates a Tape device.
+    """
+    def rewind(self):
+        """Rewinds the tape to the beginning."""
+        self.seek(0)
+
+class DeviceManager:
+    """
+    Manages the collection of IO devices attached to the SIC machine.
+    """
+    def __init__(self):
+        self._devices = {}
+
+    def add_device(self, device_id: int, device: IODevice):
+        """Registers a device with a given 8-bit ID."""
+        self._devices[device_id & 0xFF] = device
+
+    def reset(self):
+        """Resets all registered devices."""
+        for device in self._devices.values():
+            device.reset()
+
+    def get_device(self, device_id: int) -> IODevice:
+        """Retrieves the device associated with the given ID, or None if not found."""
+        return self._devices.get(device_id & 0xFF)

--- a/src/machine.py
+++ b/src/machine.py
@@ -2,6 +2,7 @@ from .memory import Memory
 from .registers import Registers
 from .cpu import CPU
 from .loader import Loader
+from .devices import DeviceManager
 
 class SICMachine:
     """
@@ -12,11 +13,12 @@ class SICMachine:
     def __init__(self):
         """
         Initializes the entire SIC machine, creating instances of
-        Memory, Registers, and CPU.
+        Memory, Registers, CPU, and DeviceManager.
         """
         self.memory = Memory()
         self.registers = Registers()
-        self.cpu = CPU(self.registers, self.memory)
+        self.device_manager = DeviceManager()
+        self.cpu = CPU(self.registers, self.memory, self.device_manager)
 
     def reset(self):
         """

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,125 @@
+import unittest
+import sys
+import os
+
+# Add the project root to the Python path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, project_root)
+
+from src.cpu import CPU
+from src.memory import Memory
+from src.registers import Registers
+from src.machine import SICMachine
+
+class MockDevice:
+    def __init__(self, ready=True):
+        self.ready = ready
+        self.read_data = []
+        self.written_data = []
+
+    def test(self) -> bool:
+        return self.ready
+
+    def read(self) -> int:
+        return self.read_data.pop(0) if self.read_data else 0
+
+    def write(self, value: int):
+        self.written_data.append(value)
+
+class TestIO(unittest.TestCase):
+    def setUp(self):
+        self.machine = SICMachine()
+        self.cpu = self.machine.cpu
+        self.memory = self.machine.memory
+        self.registers = self.machine.registers
+
+    def test_td_instruction_ready(self):
+        # Setup device ID 0xF1 as a ready device
+        device = MockDevice(ready=True)
+        self.machine.device_manager.add_device(0xF1, device)
+
+        # Instruction TD 0xF1 (Opcode 0xE0, Address 0xF1)
+        self.memory.write_word(0x2000, 0xE000F1)
+        self.registers.PC = 0x2000
+
+        self.cpu.step()
+
+        self.assertEqual(self.registers.SW, ord('<'), "SW should be '<' when device is ready")
+
+    def test_td_instruction_busy(self):
+        device = MockDevice(ready=False)
+        self.machine.device_manager.add_device(0xF2, device)
+
+        # Instruction TD 0xF2
+        self.memory.write_word(0x2000, 0xE000F2)
+        self.registers.PC = 0x2000
+
+        self.cpu.step()
+
+        self.assertEqual(self.registers.SW, ord('='), "SW should be '=' when device is busy")
+
+    def test_rd_instruction(self):
+        device = MockDevice()
+        device.read_data = [0xAB]
+        self.machine.device_manager.add_device(0xF3, device)
+
+        # Instruction RD 0xF3
+        self.memory.write_word(0x2000, 0xD800F3)
+        self.registers.PC = 0x2000
+        self.registers.A = 0x123456
+
+        self.cpu.step()
+
+        # A register is 24-bit. RD replaces only the rightmost 8 bits.
+        self.assertEqual(self.registers.A, 0x1234AB, "Register A should contain 0xAB in low 8 bits")
+
+    def test_wd_instruction(self):
+        device = MockDevice()
+        self.machine.device_manager.add_device(0xF4, device)
+
+        # Instruction WD 0xF4
+        self.memory.write_word(0x2000, 0xDC00F4)
+        self.registers.PC = 0x2000
+        self.registers.A = 0x1234CD
+
+        self.cpu.step()
+
+        self.assertEqual(device.written_data, [0xCD], "Device should have received 0xCD")
+
+    def test_console_input_device(self):
+        from src.devices import ConsoleInputDevice
+        dev = ConsoleInputDevice()
+        dev.set_input("HELLO")
+        self.assertTrue(dev.test())
+        self.assertEqual(dev.read(), ord('H'))
+        self.assertEqual(dev.read(), ord('E'))
+
+    def test_console_output_device(self):
+        from src.devices import ConsoleOutputDevice
+        dev = ConsoleOutputDevice()
+        dev.write(ord('A'))
+        dev.write(ord('B'))
+        self.assertEqual(dev.get_output(), "AB")
+
+    def test_disk_device(self):
+        from src.devices import DiskDevice
+        # Simple simulation: DiskDevice behaves like a stream for now
+        dev = DiskDevice()
+        dev.write(0xDE)
+        dev.write(0xAD)
+        # Assuming we can seek or it's just a buffer
+        dev.seek(0)
+        self.assertEqual(dev.read(), 0xDE)
+        self.assertEqual(dev.read(), 0xAD)
+
+    def test_tape_device(self):
+        from src.devices import TapeDevice
+        dev = TapeDevice()
+        dev.write(0xBE)
+        dev.write(0xEF)
+        dev.rewind()
+        self.assertEqual(dev.read(), 0xBE)
+        self.assertEqual(dev.read(), 0xEF)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This change adds support for Disk, Tape, and Console IO devices to the SIC emulator. It includes the implementation of the RD, WD, and TD instructions in the CPU, a new DeviceManager for handling device interactions, and specific simulated device classes. The implementation follows the SIC specification where the effective address of an IO instruction serves as the device ID. Comprehensive tests are included to verify the functionality of both the instructions and the simulated devices.

Fixes #5

---
*PR created automatically by Jules for task [4640330261346295215](https://jules.google.com/task/4640330261346295215) started by @jonaschen*